### PR TITLE
Fix allow to rename VF in container when using DHCP IPAM

### DIFF
--- a/sriov/main.go
+++ b/sriov/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"os"
 
 	"github.com/containernetworking/cni/pkg/ipam"
 	"github.com/containernetworking/cni/pkg/ns"
@@ -32,8 +33,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
+	old_ifname := os.Getenv("CNI_IFNAME")
+	defer os.Setenv("CNI_IFNAME", old_ifname)
 	if n.IF0NAME != "" {
 		args.IfName = n.IF0NAME
+		os.Setenv("CNI_IFNAME", args.IfName)
 	}
 
 	// Try assigning a VF from PF
@@ -112,8 +116,11 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	old_ifname := os.Getenv("CNI_IFNAME")
+	defer os.Setenv("CNI_IFNAME", old_ifname)
 	if n.IF0NAME != "" {
 		args.IfName = n.IF0NAME
+		os.Setenv("CNI_IFNAME", args.IfName)
 	}
 
 	// skip the IPAM release for the DPDK and L2 mode


### PR DESCRIPTION
By changing the CNI_IFNAME enviroment variable to the VF's new name to
support using intel-multus with renaming interface, when multus move the
interface to the container it will name the first VF eth0 and then
follow the pattern of netX where X start from 0, so when the interface
moved with sriov-cni name mutlus will not find the interface with the
name it set